### PR TITLE
Add tail recursion elimination and allow multi var assignment

### DIFF
--- a/ast/__tests__/parser.test.js
+++ b/ast/__tests__/parser.test.js
@@ -509,6 +509,28 @@ const fixture = {
       ])
     ),
   ],
+
+  MultiVarAssignment: [
+    String.raw`all l, m, n, o <- 1, true, 'b', "hello";`,
+    new Program(
+      new Block([
+        new AssignmentStatement(
+          [
+            new IdExpression('l'),
+            new IdExpression('m'),
+            new IdExpression('n'),
+            new IdExpression('o'),
+          ],
+          [
+            new NumericLiteral(1),
+            new BooleanLiteral(true),
+            new CharacterLiteral('b'),
+            new StringLiteral('hello'),
+          ]
+        ),
+      ])
+    ),
+  ],
 };
 
 describe('The parser', () => {

--- a/ast/parser.js
+++ b/ast/parser.js
@@ -107,7 +107,10 @@ const astBuilder = grammar.createSemantics().addOperation('ast', {
   IfShort(e, _when, c, _otherwise, a) {
     return new IfShort(e.ast(), c.ast(), a.ast());
   },
-  Assignment(i, _a, e) {
+  Assignment_single(i, _a, e) {
+    return new AssignmentStatement(i.ast(), e.ast());
+  },
+  Assignment_multi(_all, i, _a, e) {
     return new AssignmentStatement(i.ast(), e.ast());
   },
   BooleanType(_) {

--- a/docs/examples/tailRecursionElimination.pivot
+++ b/docs/examples/tailRecursionElimination.pivot
@@ -1,0 +1,9 @@
+gcd(num x, num y) -> num 
+  if y == 0 then return x; end
+  return gcd(x, x % y);
+end
+
+fib(num n, num a, num b) -> num
+  if n == 0 then return a; end
+  return fib(n - 1, b, a + b);
+end

--- a/docs/examples/test.pivot
+++ b/docs/examples/test.pivot
@@ -1,2 +1,0 @@
-[num] test <- [1,2,3];
-test::push(2);

--- a/generator/__tests__/javascript-generator.test.js
+++ b/generator/__tests__/javascript-generator.test.js
@@ -140,6 +140,19 @@ const fixture = {
       `
     ),
   ],
+  multiVarAssignment: [
+    `num tmp <- 0;
+    {str:num} fruitInventory <- {"apple": 20, "grapes": 100};
+    all tmp, fruitInventory:"apple" <- fruitInventory:"apple", 12;
+    `,
+    prettyJs(
+      `
+      let tmp = 0;
+      let fruitInventory = {"apple": 20, "grapes": 100};
+      [tmp, fruitInventory["apple"]] = [fruitInventory["apple"], 12];
+      `
+    ),
+  ],
 };
 
 describe('The JavaScript generator', () => {

--- a/generator/javascript-generator.js
+++ b/generator/javascript-generator.js
@@ -125,6 +125,11 @@ PrintStatement.prototype.gen = function() {
 };
 
 AssignmentStatement.prototype.gen = function() {
+  if (Array.isArray(this.target)) {
+    return `[${this.target.map(t => t.gen())}] = [${this.source.map(s =>
+      s.gen()
+    )}]`;
+  }
   return `${this.target.gen()} = ${this.source.gen()}`;
 };
 

--- a/grammar/__tests__/grammar.test.js
+++ b/grammar/__tests__/grammar.test.js
@@ -62,6 +62,8 @@ end
 x <- addFive(3);
 _ z <- (29.3) >> round;
 // a comment at the end of the program
+
+all x, y, z, p <- "apple", 5, "car", "green";
 `;
 
 describe('The syntax checker', () => {

--- a/grammar/pivot.ohm
+++ b/grammar/pivot.ohm
@@ -16,7 +16,8 @@ Pivot {
                       | Type id "<-" (CallExpression | IfShort | Exp)                            -- single
                       | "(" Type id ("," Type id)+ ")"
                         "<-" "(" NonemptyListOf<Exp, ","> ")"                                    -- multidec
-  Assignment          = (Lvalue | id) "<-" (CallExpression | IfShort | Exp) 
+  Assignment          = "all" NonemptyListOf<id, ","> "<-" NonemptyListOf<Exp, ",">              -- multi
+                      | (Lvalue | id) "<-" (CallExpression | IfShort | Exp)                      -- single
   IfStatement         = if Exp then Statement+ (else Statement+)?
   IfShort             = Exp when (CallExpression | Exp)
                         otherwise (CallExpression | IfShort | Exp)

--- a/grammar/pivot.ohm
+++ b/grammar/pivot.ohm
@@ -16,7 +16,7 @@ Pivot {
                       | Type id "<-" (CallExpression | IfShort | Exp)                            -- single
                       | "(" Type id ("," Type id)+ ")"
                         "<-" "(" NonemptyListOf<Exp, ","> ")"                                    -- multidec
-  Assignment          = "all" NonemptyListOf<(Lvalue | id), ","> "<-" NonemptyListOf<Exp, ",">              -- multi
+  Assignment          = "all" NonemptyListOf<(Lvalue | id), ","> "<-" NonemptyListOf<Exp, ",">   -- multi
                       | (Lvalue | id) "<-" (CallExpression | IfShort | Exp)                      -- single
   IfStatement         = if Exp then Statement+ (else Statement+)?
   IfShort             = Exp when (CallExpression | Exp)

--- a/grammar/pivot.ohm
+++ b/grammar/pivot.ohm
@@ -16,7 +16,7 @@ Pivot {
                       | Type id "<-" (CallExpression | IfShort | Exp)                            -- single
                       | "(" Type id ("," Type id)+ ")"
                         "<-" "(" NonemptyListOf<Exp, ","> ")"                                    -- multidec
-  Assignment          = "all" NonemptyListOf<id, ","> "<-" NonemptyListOf<Exp, ",">              -- multi
+  Assignment          = "all" NonemptyListOf<(Lvalue | id), ","> "<-" NonemptyListOf<Exp, ",">              -- multi
                       | (Lvalue | id) "<-" (CallExpression | IfShort | Exp)                      -- single
   IfStatement         = if Exp then Statement+ (else Statement+)?
   IfShort             = Exp when (CallExpression | Exp)

--- a/semantics/__test__/semantic_errors.test.js
+++ b/semantics/__test__/semantic_errors.test.js
@@ -51,13 +51,6 @@ const errors = [
   ],
   [
     'condition is deterministic',
-    `while 5 > 2 do
-      num x <- 5;
-    end
-    `,
-  ],
-  [
-    'condition is deterministic',
     `repeat
       num x <- 5;
     when true end

--- a/semantics/__test__/semantic_errors.test.js
+++ b/semantics/__test__/semantic_errors.test.js
@@ -184,6 +184,25 @@ const errors = [
     'Contains method returns boolean',
     `str ownIt <- {"tv": 2, "radio": 0, "bed": 1}::contains("tv");`,
   ],
+  [
+    'Number of targets and sources do not match',
+    `
+    all num x, y, z <- 1, 2, 3;
+    all x, y <- 2, 4, 6;
+    `,
+  ],
+  [
+    'Incompatible types in multi var assignment ',
+    `
+    all num ll, p <- 0, 0;
+    bool m <- false;
+    char n <- 'a';
+    str o <- "bye";
+    [char] zq <- ['a', 'b', 'c'];
+    
+    all ll, m, n, o, p, zq <- 1, true, 'b', "hello", ll + zq:0, [2,2,2,2];
+    `,
+  ],
 ];
 
 describe('The semantic analyzer', () => {

--- a/semantics/__test__/semantics.test.js
+++ b/semantics/__test__/semantics.test.js
@@ -193,6 +193,14 @@ inventory <- inventory::del("tv");
 [num] listInventory2 <- {"tv": 2, "radio": 0, "bed": 1}::values();
 
 sirList() -> [num] return [1,2,3,4,5]; end
+
+all num ll, p <- 0, 0;
+bool m <- false;
+char n <- 'a';
+str o <- "bye";
+[num] zq <- [2,3,1,0];
+
+all ll, m, n, o, p, zq <- 1, true, 'b', "hello", ll + zq:0, [2,2,2,2];
 `;
 
 describe('The semantic analyzer', () => {

--- a/semantics/analyzer.js
+++ b/semantics/analyzer.js
@@ -115,7 +115,11 @@ VariableDeclaration.prototype.analyze = function(context) {
 };
 
 AssignmentStatement.prototype.analyze = function(context) {
-  if (this.target.constructor === SubscriptedExp) {
+  if (Array.isArray(this.target)) {
+    this.target.forEach(element => element.analyze(context));
+    this.source.forEach(element => element.analyze(context));
+    check.hasCompatibleTargetsAndSources(this.target, this.source);
+  } else if (this.target.constructor === SubscriptedExp) {
     this.source.analyze(context);
   } else {
     const ref = context.lookup(this.target.id);

--- a/semantics/analyzer.js
+++ b/semantics/analyzer.js
@@ -261,7 +261,6 @@ ListExpression.prototype.analyze = function() {
 
 WhileStatement.prototype.analyze = function(context) {
   this.condition.analyze(context);
-  check.conditionIsDetermistic(this.condition);
   this.bodyContext = context.createChildContextForLoop();
   this.body.analyze(this.bodyContext);
 };

--- a/semantics/check.js
+++ b/semantics/check.js
@@ -245,4 +245,13 @@ module.exports = {
   isGreaterThan(start, end) {
     doCheck(end > start, `${end} is not greater than ${start}`);
   },
+  hasCompatibleTargetsAndSources(targets, sources) {
+    doCheck(
+      targets.length === sources.length,
+      `${targets.length} number of targets does not match ${sources.length} sources`
+    );
+    targets.map((target, index) => {
+      this.hasCompatibleTypes(target.ref.type, sources[index]);
+    });
+  },
 };

--- a/semantics/check.js
+++ b/semantics/check.js
@@ -250,8 +250,8 @@ module.exports = {
       targets.length === sources.length,
       `${targets.length} number of targets does not match ${sources.length} sources`
     );
-    targets.map((target, index) => {
-      this.hasCompatibleTypes(target.ref.type, sources[index]);
-    });
+    targets.map((target, index) =>
+      this.hasCompatibleTypes(target.type, sources[index])
+    );
   },
 };

--- a/semantics/optimizer.js
+++ b/semantics/optimizer.js
@@ -132,7 +132,6 @@ FunctionDeclaration.prototype.optimize = function() {
   this.body = this.body.optimize();
   const returnStmt = this.body.statements[this.body.statements.length - 1].item;
   if (isFuncRecursive(this, returnStmt)) {
-    console.log('nope');
     this.body = new Block([
       new WhileStatement(
         new BooleanLiteral(true),

--- a/semantics/optimizer.js
+++ b/semantics/optimizer.js
@@ -107,7 +107,6 @@ VariableDeclaration.prototype.optimize = function() {
 };
 
 AssignmentStatement.prototype.optimize = function() {
-  console.log(this.target);
   this.target = this.target.optimize();
   this.source = this.source.optimize();
   if (this.target == this.source) return null;

--- a/semantics/optimizer.js
+++ b/semantics/optimizer.js
@@ -152,7 +152,7 @@ FieldExp.prototype.optimize = function() {
 IfStatement.prototype.optimize = function() {
   this.condition = this.condition.optimize();
   this.body = this.body.optimize();
-  this.elseBody = this.body.optimize();
+  this.elseBody = this.elseBody ? this.elseBody.optimize() : null;
   return this;
 };
 


### PR DESCRIPTION
## List of changes

- Added tail recursion elimination to reduce stack usage
- Removed `determinism` semantic error from while loops to allow while true
- Updated grammar, parser, semantics and generator to allow and generate multi variable assignments.
  - `all a, b, c <- ['c', "hello", false];` in Pivot now generates to `[a, b, c] = ['c', "hello", false]` in JavaScript


###  Tail Recursion Elimination Example
#### Pivot pre-optimization
```
fib(num n, num a, num b) -> num
  if n == 0 then return a; end
  return fib(n - 1, b, a + b);
end
``` 
#### Pivot post-optimization 
>Optimization doesn't actually change source, but this is the optimized ast visualized in source
```
fib(num n, num a, num b) -> num
  while true do
    if n == 0 then return a; end
    all n, a, b <- n - 1, b, a +b;
  end
end
``` 
#### Generated JavaScript post-optimization
```JavaScript
function gcd(x, y) {
  while (true) {
    if (y === 0) { return x; }
    [x, y] = [y, x % y];
  }
}
```